### PR TITLE
Add a post and a chain example endpoints

### DIFF
--- a/sys/examples.js
+++ b/sys/examples.js
@@ -72,7 +72,6 @@ class Example {
         });
     }
 
-
     meanTimeserie(hyper, req) {
         // Returns mean of the timeserie specified in the request
 
@@ -99,16 +98,27 @@ class Example {
             );
 
     }
+
+    fakePost(hyper, req) {
+        // Build simple response out of url and body params
+        var body = {};
+        body[req.params.url_param] = req.body.body_param;
+        return fsUtil.normalizeResponse({
+            status: 200,
+            body: body
+        });
+    }
 }
 
 module.exports = function(options) {
-    var tst = new Example(options);
+    var example = new Example(options);
 
     return {
         spec: spec,
         operations: {
-            fakeTimeserie: tst.fakeTimeserie.bind(tst),
-            meanTimeserie: tst.meanTimeserie.bind(tst)
+            fakeTimeserie: example.fakeTimeserie.bind(example),
+            meanTimeserie: example.meanTimeserie.bind(example),
+            fakePost: example.fakePost.bind(example)
         }
     };
 };

--- a/sys/examples.yaml
+++ b/sys/examples.yaml
@@ -28,3 +28,17 @@ paths:
         get:
           summary: Get the mean of a fake timeserie
           operationId: meanTimeserie
+
+    /fake-post/{url_param}:
+        post:
+          summary: Test a post endpoint
+          operationId: fakePost
+          parameters:
+            - name: url_param
+              in: path
+              type: string
+              required: true
+            - name: body_param
+              in: formData
+              type: string
+              required: true

--- a/test/features/examples/examples.js
+++ b/test/features/examples/examples.js
@@ -16,6 +16,10 @@ describe('examples endpoints', function () {
     //Start server before running tests
     before(function () { return server.start(); });
 
+    // ************************************
+    // fake-timeserie
+    // ************************************
+
     var endpoint = '/examples/fake-timeserie';
 
     // Test Endpoint
@@ -91,6 +95,10 @@ describe('examples endpoints', function () {
             assert.deepStrictEqual(res.body.items[59].ts, '2017-01-01T00:00:59.000Z');
         });
     });
+
+    // ************************************
+    // mean-fake-timeserie
+    // ************************************
 
     var endpointMean = '/examples/mean-fake-timeserie';
 
@@ -168,5 +176,63 @@ describe('examples endpoints', function () {
         });
     });
 
+
+    // ************************************
+    // fake-post
+    // ************************************
+
+    var endpointPost = '/examples/fake-post';
+
+    it('should return 404 when no url_param is set (wrong URL pattern)', function () {
+        return preq.post({
+            uri: server.config.fsURL + endpointPost
+        }).catch(function(res) {
+            assert.deepEqual(res.status, 404);
+        });
+    });
+
+    it('should return 400 when url_param is set but not body_param', function () {
+        return preq.post({
+            uri: server.config.fsURL + endpointPost + '/url_value'
+        }).catch(function(res) {
+            assert.deepEqual(res.status, 400);
+        });
+    });
+
+    it('should return 200 with url_param and body_param in response body', function () {
+        return preq.post({
+            uri: server.config.fsURL + endpointPost + '/url_value',
+            headers: { 'content-type': 'multipart/form-data'},
+            body: { body_param: 'body_value' }
+        }).then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepStrictEqual(res.body.url_value, 'body_value');
+        });
+    });
+
+    // ************************************
+    // fake-chain
+    // ************************************
+
+    var endpointChain = '/examples/fake-chain';
+
+    it('should return 400 when body_param is not set', function () {
+        return preq.post({
+            uri: server.config.fsURL + endpointChain
+        }).catch(function(res) {
+            assert.deepEqual(res.status, 400);
+        });
+    });
+
+    it('should return 200 with correct response body when body_param is set', function () {
+        return preq.post({
+            uri: server.config.fsURL + endpointChain,
+            headers: { 'content-type': 'multipart/form-data'},
+            body: { chain_body_param: 'dummy' }
+        }).then(function(res) {
+            assert.deepEqual(res.status, 200);
+            assert.deepStrictEqual(res.body['fake-chain-2'], 'value-fake-chain-2');
+        });
+    });
 
 });

--- a/v1/examples.yaml
+++ b/v1/examples.yaml
@@ -134,6 +134,103 @@ paths:
               uri: /{domain}/sys/examples/fake-timeserie/{from}/{to}/{step}
       x-monitor: false
 
+  /fake-post/{url_param}:
+    post:
+      tags:
+        - EBDO FeatureService Examples
+      summary: Fake post endpoint
+      description: |
+        Fake post endpoint returning the parameters given in url and in body,
+        using url-value as key to the body-value.
+      produces:
+        - application/json
+      parameters:
+        - name: url_param
+          in: path
+          description: A fake url parameter
+          type: string
+          required: true
+        - name: body_param
+          in: formData
+          description: A fake body parameter
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The parameters provided
+          schema:
+            $ref: '#/definitions/post-parameters'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        - post_to_backend:
+            request:
+              method: post
+              uri: /{domain}/sys/examples/fake-post/{url_param}
+              headers:
+                content-type: multipart/form-data
+              body:
+                body_param: '{{body_param}}'
+      x-monitor: false
+
+  /fake-chain:
+    post:
+      tags:
+        - EBDO FeatureService Examples
+      summary: Fake-chain endpoint using post
+      description: |
+        Fake chain using fake-post two times is a row
+      produces:
+        - application/json
+      parameters:
+        - name: chain_body_param
+          in: formData
+          description: A fake body parameter for validity
+          type: string
+          required: true
+      responses:
+        '200':
+          description: The parameters provided
+          schema:
+            $ref: '#/definitions/post-parameters'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/problem'
+      x-request-handler:
+        # First step - Dummy call to fake-post
+        - validate_first_step:
+            request:
+              method: post
+              uri: /{domain}/sys/examples/fake-post/fake-chain-1
+              headers:
+                content-type: multipart/form-data
+              body:
+                body_param: '{{chain_body_param}}'
+
+        - execute_second_step:
+            request:
+              method: post
+              uri: /{domain}/sys/examples/fake-post/fake-chain-2
+              headers:
+                content-type: multipart/form-data
+              body:
+                body_param: value-fake-chain-2
+
+        - return_step:
+            return:
+              status: 200
+              headers: '{{execute_second_step.headers}}'
+              body: '{{execute_second_step.body}}'
+
+      x-monitor: false
+
+
+
+
+
 definitions:
   # A https://tools.ietf.org/html/draft-nottingham-http-problem
   problem:
@@ -184,3 +281,10 @@ definitions:
             mean:
               type: number
               format: double
+
+  post-parameters:
+    properties:
+      url_parameter:
+        type: string
+      body_parameter:
+        type: string


### PR DESCRIPTION
In order to help further development, this patch adds
two new example endpoints. One makes use of post and
shows how to parse body-parameters, the other reuses
the post one in a chain, to show how to make use of
flow in Hyperswitch.